### PR TITLE
Initial bot test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,3 @@ DEPENDENCIES
   slack-poster (~> 1.0.1)
   thin
   timecop
-
-BUNDLED WITH
-   1.10.6

--- a/config/18f.yml
+++ b/config/18f.yml
@@ -1,0 +1,10 @@
+18f:
+  channel: "#open-pull-requests"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - DO NOT MERGE
+    - WIP
+
+  exclude_labels:
+    - wip

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -8,7 +8,7 @@ class GithubFetcher
   def initialize(team_members_accounts, use_labels, exclude_labels, exclude_titles)
     @github = Octokit::Client.new(:access_token => ENV['GITHUB_TOKEN'])
     @github.user.login
-    Octokit.auto_paginate = true
+    @github.auto_paginate = true
     @people = team_members_accounts
     @use_labels = use_labels
     @exclude_labels = exclude_labels.map(&:downcase).uniq if exclude_labels
@@ -67,7 +67,7 @@ class GithubFetcher
   end
 
   def hidden?(pull_request, repo)
-    excluded_label?(pull_request, repo) || excluded_title?(pull_request.title) || !person_subscribed?(pull_request)
+    excluded_label?(pull_request, repo) || excluded_title?(pull_request.title)
   end
 
   def excluded_label?(pull_request, repo)

--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -93,6 +93,6 @@ class SlackPoster
   end
 
   def channel
-    @team_channel = '#angry-seal-bot-test' if ENV["DYNO"].nil?
+    @team_channel = '#transient' if ENV["DYNO"].nil?
   end
 end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -94,6 +94,7 @@ describe 'GithubFetcher' do
 
   before do
     expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
+    expect(fake_octokit_client).to receive(:auto_paginate=).with(true)
     expect(fake_octokit_client).to receive_message_chain('user.login')
     expect(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov").and_return(double(items: [pull_2266, pull_2248]))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@
 #
 require 'timecop'
 
-ENV['SEAL_ORGANISATION'] ||= "alphagov"
+ENV['SEAL_ORGANISATION'] = "alphagov"
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
- Fix auto pagination
- Ignore team members for now to fetch all org repos
- Set test channel to `#transient`
- Configure exclusion of PRs based on words in their title and/or labels
- Remove memoization when setting `ENV['SEAL_ORGANISATION']` in tests.
  Otherwise, the value won't be 'alphagov' if the ENV var is already
  set to something else.
