### PR TITLE
Add option to configure ignored repos

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,26 +13,6 @@
     "GITHUB_TOKEN": {
       "description": "Your Github token (obtainable at https://github.com/settings/tokens)"
     },
-    "GITHUB_MEMBERS": {
-      "description": "Comma separated list of github members",
-      "required": false
-    },
-    "GITHUB_USE_LABELS": {
-      "description": "Comma separated list of labels to include",
-      "required": false
-    },
-    "GITHUB_EXCLUDE_LABELS": {
-      "description": "Comma separated list of labels to exclude",
-      "required": false
-    },
-    "GITHUB_EXCLUDE_TITLES": {
-      "description": "Comma separated list of titles e.g (WIP) to exclude",
-      "required": false
-    },
-    "QUOTES": {
-      "description": "Comma separated list of sentences you would like the Seal to post. Can be used for inspirational quotes or reminders.",
-      "required": false
-    },
     "SLACK_WEBHOOK": {
       "description": "Your Slack Incoming Webhook token (obtainable at https://slack.com/services/new/incoming-webhook)"
     },

--- a/config/18f.yml
+++ b/config/18f.yml
@@ -2,9 +2,18 @@
   channel: "#open-pull-requests"
 
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - DO NOT MERGE
-    - WIP
+    - '[DO NOT MERGE]'
+    - 'DO NOT MERGE'
+    - "DON'T MERGE"
+    - 'DONT MERGE'
+    - 'WORK IN PROGRESS'
+    - 'WIP'
 
   exclude_labels:
-    - wip
+    - 'wip'
+
+  ignored_repos:
+    - 'C2'
+    - 'college-choice'
+    - 'openFEC'
+    - 'openFEC-web-app'


### PR DESCRIPTION
**Why**:
Since the bot is currently configured to post all open PRs across the 18F GitHub org, we want to reduce the noise by being able to ignore certain repos, namely ones that are active and presumably don't need outside help for reviews.

**How**:
Add support for a new entry in the YAML config file.

Based on the original code, this would have meant adding another assignment to `Seal#team_params(team)`, and increasing the number of parameters passed in to a `GithubFetcher.new`.

Rather than going down this path for every new configuration we want to add, I simplified the method so that it passes in the team hash directly to `GithubFetcher`. I also removed the option to use ENV-based configuration to keep things simple and consistent, and added a check to make sure a YAML config file is present before the bot can run.
