### PR TITLE
Add language-based teams

### DIFF
--- a/config/18f.yml
+++ b/config/18f.yml
@@ -1,19 +1,23 @@
-18f:
-  channel: "#open-pull-requests"
+css:
+  channel: '#frontend-pull-reqs'
+  language: 'css'
 
-  exclude_titles:
-    - '[DO NOT MERGE]'
-    - 'DO NOT MERGE'
-    - "DON'T MERGE"
-    - 'DONT MERGE'
-    - 'WORK IN PROGRESS'
-    - 'WIP'
+go:
+  channel: '#go-pull-requests'
+  language: 'go'
 
-  exclude_labels:
-    - 'wip'
+javascript:
+  channel: '#js-pull-requests'
+  language: 'javascript'
 
-  ignored_repos:
-    - 'C2'
-    - 'college-choice'
-    - 'openFEC'
-    - 'openFEC-web-app'
+python:
+  channel: '#python-pull-requests'
+  language: 'python'
+
+ruby:
+  channel: '#ruby-pull-requests'
+  language: 'ruby'
+
+shell:
+  channel: '#shell-pull-requests'
+  language: 'shell'

--- a/config/global.yml
+++ b/config/global.yml
@@ -1,0 +1,18 @@
+exclude_titles:
+  - '[DO NOT MERGE]'
+  - 'DO NOT MERGE'
+  - "DON'T MERGE"
+  - 'DONT MERGE'
+  - "[DON'T MERGE]"
+  - 'WORK IN PROGRESS'
+  - 'WIP'
+  - '[WIP]'
+
+exclude_labels:
+  - 'wip'
+
+ignored_repos:
+  - 'C2'
+  - 'college-choice'
+  - 'openFEC'
+  - 'openFEC-web-app'


### PR DESCRIPTION
**Why**:
To be able to break down the list of open PRs into separate buckets based on the language of the PR. That way, all Ruby PRs will go to the #ruby-pull-requests Slack channel, all Python PRs will go to #python-pull-requests, and so on.

**How**:
- Move the global configuration (title, labels, repos to exclude) to a separate `global.yml` file, and create language-based teams in the `18f.yml` file.
- Update the GitHub query to filter by the team's language

I tested this and it works great. Check out the slack channels listed in `18f.yml` to see what the bot posted.
