### PR TITLE
Add identity and data-private to ignored repos

### DIFF
--- a/config/global.yml
+++ b/config/global.yml
@@ -16,3 +16,5 @@ ignored_repos:
   - 'college-choice'
   - 'openFEC'
   - 'openFEC-web-app'
+  - 'identity'
+  - 'data-private'


### PR DESCRIPTION
**Why**: identity is an active project regularly reviewed by the team members, and data-private is deprecated.
