### PR TITLE
Add support for individual repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,22 @@
 ##What is it?
 
 A Slack bot forked from [binaryberry](https://github.com/binaryberry/seal) that
-checks GitHub once a day on weekdays for open pull requests across all 18F
-repos, and posts them to language-specific channels, such as
-`#ruby-pull-requests`.
+checks GitHub once a day on weekdays for open pull requests across all repos
+belonging to a GitHub organization, and posts them to language-specific Slack
+channels, such as `#ruby-pull-requests`. Notifications for individual repos can
+also be configured.
+
+The goal is to encourage people to review pull requests in a timely manner, and
+by organizing the notifications into language-specific channels, it makes it
+easier and less noisy to view pull requests that align with your expertise.
 
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/informative.png)
 ![image](https://github.com/binaryberry/seal/blob/master/images/readme/angry.png)
 
 ##How to use it?
+
+### Main configuration
+
 Create a YAML file named after your GitHub organization, and place it in the
 `config` folder. For example, `config/18f.yml`. Create entries for each
 language, and specify the Slack channel the bot should post to. For example:
@@ -20,7 +28,23 @@ language, and specify the Slack channel the bot should post to. For example:
 ruby:
   channel: '#ruby-pull-requests'
   language: 'ruby'
+
+python:
+  channel: '#python-pull-requests'
+  language: 'python'
 ```
+
+In addition to language-based entries, you can also specify a specific repo.
+For example, if a team that works on `awesome_repo` wants to integrate Seal
+into their Slack channel, they would add the following to the YAML file:
+
+```yaml
+awesome-repo:
+  channel: '#channel-for-awesome-repo'
+  repo: 'awesome-repo'
+```
+
+### Customization
 
 Modify `config/global.yml` to suit your needs. You can ignore pull requests
 whose title or labels contain certain strings, such as `WIP`. You can also
@@ -38,12 +62,15 @@ ignored_repos:
   - 'C2'
 ```
 
-Configure the required environment variables in your shell profile:
+### Environment variables
+
+Configure the required environment variables. To test the bot locally, you
+can set the variables by running the following commands in your Terminal:
 
 ```sh
 export SEAL_ORGANISATION="your_github_organisation"
-export GITHUB_TOKEN="get_your_github_token_from_yourgithub_settings"
-export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channel"
+export GITHUB_TOKEN="your_github_token_from_your_github_settings"
+export SLACK_WEBHOOK="your_incoming_webhook_link_for_your_slack_group_channel"
 ```
 
 - To get a new `GITHUB_TOKEN`, head to: https://github.com/settings/tokens
@@ -52,17 +79,21 @@ export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channe
   You can configure the webhook with any channel. You'll still be able to post
   to multiple channels.
 
-To test the script locally, go to Slack and create a channel or private group
-called "#seal-bot-test". Then run `./bin/seal.rb` from your command line. You
-should see a post in the #seal-bot-test channel.
+### Emojis
 
-You should also set up the following custom emojis in Slack:
+Set up the following custom emojis in Slack:
 - :informative_seal:
 - :angrier_seal:
 - :seal_of_approval:
 - :happyseal:
 
 You can use the images in `images/emoji/Everyday images` that have the corresponding names.
+
+### Test the bot
+
+To test the script locally, go to Slack and create a channel or private group
+called `#seal-bot-test`. Then run `./bin/seal.rb` from your command line. You
+should see a post in the `#seal-bot-test` channel.
 
 When that works, you can push the app to Heroku, add the `GITHUB_TOKEN` and
 `SLACK_WEBHOOK` environment variables to Heroku, and use the [Heroku scheduler

--- a/config/18f.yml
+++ b/config/18f.yml
@@ -21,3 +21,7 @@ ruby:
 shell:
   channel: '#shell-pull-requests'
   language: 'shell'
+
+identity-idp:
+  channel: '#identity-partners'
+  repo: 'identity-idp'

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -51,6 +51,10 @@ class GithubFetcher
     team_config['language']
   end
 
+  def repo
+    "#{ORGANISATION}/#{team_config['repo']}"
+  end
+
   def present_pull_request(pull_request, repo_name)
     pr = {}
     pr['title'] = pull_request.title
@@ -65,7 +69,15 @@ class GithubFetcher
   end
 
   def pull_requests_from_github
-    @github.search_issues("is:pr state:open user:#{ORGANISATION} language:#{language}").items
+    @github.search_issues(search_parameters).items
+  end
+
+  def search_parameters
+    if language
+      "is:pr state:open user:#{ORGANISATION} language:#{language}"
+    elsif repo
+      "is:pr state:open repo:#{repo}"
+    end
   end
 
   def count_comments(pull_request, repo)

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -60,8 +60,8 @@ describe 'GithubFetcher' do
 
   let(:team_config) do
     {
-      'language' => nil,
-      'channel' => nil
+      'language' => 'ruby',
+      'channel' => '#ruby'
     }
   end
 
@@ -87,6 +87,7 @@ describe 'GithubFetcher' do
            updated_at: '2015-07-17 01:00:44 UTC'
           )
   end
+
   let(:comments_2266) do [
       "You should add more seal images on the front end",
       "Sure! I have done it now",
@@ -122,12 +123,14 @@ describe 'GithubFetcher' do
     allow(github_fetcher).to receive(:global_config).and_return(global_config)
   end
 
-  context 'when the team config does not include a language' do
+  context 'when the team config does not include a language, but has a repo' do
     before do
       setup_fake_octokit_client
 
+      team_config.merge!('repo' => 'awesome_repo', 'language' => nil)
+
       expect(fake_octokit_client).to receive(:search_issues).
-        with("is:pr state:open user:alphagov language:").
+        with("is:pr state:open repo:alphagov/awesome_repo").
         and_return(double(items: [pull_2266, pull_2248]))
     end
 
@@ -240,8 +243,6 @@ describe 'GithubFetcher' do
     end
 
     it 'adds a filter for that language to the GitHub query' do
-      team_config.merge!('language' => 'ruby')
-
       expect(fake_octokit_client).to receive(:search_issues).
         with("is:pr state:open user:alphagov language:ruby").
         and_return(double(items: [pull_2266, pull_2248]))


### PR DESCRIPTION
**Why**: Some teams might want to integrate Seal into their Slack
channel for their individual repo. This PR allows individual repos to
be added to the YAML config.
