### PR TITLE
Ignore identity-* repos from #ruby-pull-requests

### DIFF
--- a/config/global.yml
+++ b/config/global.yml
@@ -14,7 +14,11 @@ exclude_labels:
 ignored_repos:
   - 'C2'
   - 'college-choice'
+  - 'data-private'
+  - 'identity-dashboard'
+  - 'identity-devops'
+  - 'identity-idp'
+  - 'identity-private'
+  - 'identity-sp-rails'
   - 'openFEC'
   - 'openFEC-web-app'
-  - 'identity'
-  - 'data-private'


### PR DESCRIPTION
**Why**: They are actively maintained. #ruby-pull-requests is mainly
for repos whose PRs suffer from lack of attention.
